### PR TITLE
feat: paginação, busca por nome e filtro por tipo

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": "20.x"
+  },
   "bugs": {
     "url": "https://github.com/CaioDSPeixoto/Pokemon/issues"
   },

--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -1,5 +1,4 @@
 import Image from 'next/image'
-
 import styles from '../../styles/About.module.css'
 
 export default function About() {
@@ -7,8 +6,22 @@ export default function About() {
     <>
       <div className={styles.about}>
         <h1>Sobre o projeto</h1>
-        <Image src="/images/pokemons.png" width="200" height="200"></Image>
-        <p>Texto aqui</p>
+        <Image src="/images/pokemons.png" width="200" height="200" alt="Pokémon" />
+        <p>
+          Este é um projeto de estudo desenvolvido com <strong>Next.js</strong>,
+          utilizando a <strong>PokéAPI</strong> para exibir informações sobre os Pokémon.
+        </p>
+        <p>
+          Foram explorados conceitos como roteamento dinâmico, geração estática
+          de páginas (SSG) com <code>getStaticProps</code> e <code>getStaticPaths</code>,
+          renderização no servidor (SSR) com <code>getServerSideProps</code>,
+          e consumo de APIs externas.
+        </p>
+        <p>
+          A aplicação permite listar todos os Pokémon com paginação, buscar por nome
+          e filtrar por tipo, além de visualizar detalhes como tipos, altura, peso,
+          habilidades e stats base de cada um.
+        </p>
       </div>
     </>
   )

--- a/pages/contact/index.js
+++ b/pages/contact/index.js
@@ -1,12 +1,31 @@
 import Head from 'next/head'
+import styles from '../../styles/Contact.module.css'
 
 export default function Contact() {
   return (
     <>
       <Head>
-        <title>Página de Contato</title>
+        <title>Contato | Pokemon</title>
       </Head>
-      <h1>Página de Contato</h1>
+      <div className={styles.contact}>
+        <h1>Contato</h1>
+        <p>Tem alguma dúvida ou sugestão? Preencha o formulário abaixo.</p>
+        <form className={styles.form}>
+          <div className={styles.field}>
+            <label htmlFor="name">Nome</label>
+            <input id="name" type="text" placeholder="Seu nome" />
+          </div>
+          <div className={styles.field}>
+            <label htmlFor="email">E-mail</label>
+            <input id="email" type="email" placeholder="seu@email.com" />
+          </div>
+          <div className={styles.field}>
+            <label htmlFor="message">Mensagem</label>
+            <textarea id="message" rows="5" placeholder="Sua mensagem..." />
+          </div>
+          <button type="submit">Enviar</button>
+        </form>
+      </div>
     </>
   )
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,41 +1,179 @@
 import styles from '../styles/Home.module.css'
-
 import Image from 'next/image'
-
 import Card from '../components/Card'
+import { useRouter } from 'next/router'
+import { useState, useEffect } from 'react'
 
-export async function getStaticProps() {
+const TYPES = [
+  'normal', 'fire', 'water', 'grass', 'electric', 'ice',
+  'fighting', 'poison', 'ground', 'flying', 'psychic', 'bug',
+  'rock', 'ghost', 'dragon', 'dark', 'steel', 'fairy'
+]
 
-  const maxPokemons = 20
-  const api = process.env.NEXT_URL_POKEMON
+const TYPE_PT = {
+  normal: 'Normal', fire: 'Fogo', water: 'Água', grass: 'Planta',
+  electric: 'Elétrico', ice: 'Gelo', fighting: 'Luta', poison: 'Veneno',
+  ground: 'Terra', flying: 'Voador', psychic: 'Psíquico', bug: 'Inseto',
+  rock: 'Pedra', ghost: 'Fantasma', dragon: 'Dragão', dark: 'Sombrio',
+  steel: 'Aço', fairy: 'Fada'
+}
 
-  const res = await fetch(`${api}/?limit=${maxPokemons}`)
-  const data = await res.json()
+const LIMIT = 20
 
-  // add pokmeon index
-  data.results.forEach((item, index) => {
-    item.id = index + 1
-  })
+export async function getServerSideProps({ query }) {
+  const page = Math.max(1, parseInt(query.page) || 1)
+  const type = query.type || ''
+  const search = query.search || ''
+  const offset = (page - 1) * LIMIT
+
+  let pokemons = []
+  let totalPages = 1
+
+  try {
+    if (type) {
+      const res = await fetch(`https://pokeapi.co/api/v2/type/${type}`)
+      const data = await res.json()
+      const all = data.pokemon
+        .map(p => ({
+          name: p.pokemon.name,
+          id: parseInt(p.pokemon.url.split('/').filter(Boolean).pop())
+        }))
+        .filter(p => p.id < 10000)
+        .sort((a, b) => a.id - b.id)
+
+      totalPages = Math.ceil(all.length / LIMIT)
+      pokemons = all.slice(offset, offset + LIMIT)
+    } else if (search) {
+      const res = await fetch(`https://pokeapi.co/api/v2/pokemon?limit=1302&offset=0`)
+      const data = await res.json()
+      const filtered = data.results
+        .map(p => ({
+          name: p.name,
+          id: parseInt(p.url.split('/').filter(Boolean).pop())
+        }))
+        .filter(p => p.id < 10000 && p.name.includes(search.toLowerCase()))
+
+      totalPages = Math.ceil(filtered.length / LIMIT)
+      pokemons = filtered.slice(offset, offset + LIMIT)
+    } else {
+      const res = await fetch(`https://pokeapi.co/api/v2/pokemon?limit=${LIMIT}&offset=${offset}`)
+      const data = await res.json()
+      totalPages = Math.ceil(data.count / LIMIT)
+      pokemons = data.results.map(p => ({
+        name: p.name,
+        id: parseInt(p.url.split('/').filter(Boolean).pop())
+      }))
+    }
+  } catch {
+    pokemons = []
+  }
 
   return {
-    props: {
-      pokemons: data.results,
-    },
+    props: { pokemons, totalPages, currentPage: page, activeType: type, activeSearch: search }
   }
 }
 
-export default function Home({ pokemons }) {
+export default function Home({ pokemons, totalPages, currentPage, activeType, activeSearch }) {
+  const router = useRouter()
+  const [searchInput, setSearchInput] = useState(activeSearch)
+
+  useEffect(() => {
+    setSearchInput(activeSearch)
+  }, [activeSearch])
+
+  function handleSearch(e) {
+    e.preventDefault()
+    if (!searchInput.trim()) return
+    router.push({ pathname: '/', query: { search: searchInput.trim(), page: 1 } })
+  }
+
+  function handleTypeClick(t) {
+    if (t === activeType) {
+      router.push('/')
+    } else {
+      setSearchInput('')
+      router.push({ pathname: '/', query: { type: t, page: 1 } })
+    }
+  }
+
+  function handleClear() {
+    setSearchInput('')
+    router.push('/')
+  }
+
+  function changePage(newPage) {
+    const q = { page: newPage }
+    if (activeType) q.type = activeType
+    if (activeSearch) q.search = activeSearch
+    router.push({ pathname: '/', query: q })
+  }
+
   return (
     <>
       <div className={styles.title_container}>
         <h1 className={styles.title}>Poke<span>mon</span></h1>
-        <Image src="/images/pokeball.png" width="50" height="50" alt="Pokemon"></Image>
+        <Image src="/images/pokeball.png" width="50" height="50" alt="Pokemon" />
       </div>
-      <div className={styles.pokemon_container}>
-        {pokemons.map((pokemon) => (
-          <Card key={pokemon.id} pokemon={pokemon} />
-        ))}
+
+      <div className={styles.filters}>
+        <form onSubmit={handleSearch} className={styles.search_form}>
+          <input
+            className={styles.search_input}
+            type="text"
+            placeholder="Buscar por nome..."
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
+          />
+          <button type="submit" className={styles.search_btn}>Buscar</button>
+          {(activeType || activeSearch) && (
+            <button type="button" className={styles.clear_btn} onClick={handleClear}>
+              Limpar
+            </button>
+          )}
+        </form>
+
+        <div className={styles.types_filter}>
+          {TYPES.map(t => (
+            <button
+              key={t}
+              onClick={() => handleTypeClick(t)}
+              className={`${styles.type_btn} ${styles[`type_btn_${t}`]} ${activeType === t ? styles.active : ''}`}
+            >
+              {TYPE_PT[t]}
+            </button>
+          ))}
         </div>
+      </div>
+
+      {pokemons.length === 0 ? (
+        <p className={styles.empty}>Nenhum Pokémon encontrado.</p>
+      ) : (
+        <div className={styles.pokemon_container}>
+          {pokemons.map(pokemon => (
+            <Card key={pokemon.id} pokemon={pokemon} />
+          ))}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className={styles.pagination}>
+          <button
+            className={styles.page_btn}
+            onClick={() => changePage(currentPage - 1)}
+            disabled={currentPage <= 1}
+          >
+            Anterior
+          </button>
+          <span className={styles.page_info}>Página {currentPage} de {totalPages}</span>
+          <button
+            className={styles.page_btn}
+            onClick={() => changePage(currentPage + 1)}
+            disabled={currentPage >= totalPages}
+          >
+            Próxima
+          </button>
+        </div>
+      )}
     </>
   )
 }

--- a/pages/pokemon/[pokemonId].js
+++ b/pages/pokemon/[pokemonId].js
@@ -1,69 +1,101 @@
 import Image from 'next/image'
+import Link from 'next/link'
 
 import styles from '../../styles/Pokemon.module.css'
 
-export const getStaticPaths = async() => {
-    const maxPokemons = 20
-    const api = process.env.NEXT_URL_POKEMON
-
-    const res = await fetch(`${api}/?limit=${maxPokemons}`)
-    const data = await res.json()
-
-    // params
-    const paths = data.results.map((pokemon, index) => {
-        return {
-            params: {pokemonId: (index + 1).toString()}
-        }
-    })
-
-    return {
-        paths,
-        fallback: false
-    }
+export const getStaticPaths = async () => {
+  return { paths: [], fallback: 'blocking' }
 }
 
-export const getStaticProps = async(context) => {
+export const getStaticProps = async (context) => {
+  const id = context.params.pokemonId
 
-    const id = context.params.pokemonId
-    
-    const res = await fetch(`${process.env.NEXT_URL_POKEMON}${id}`)
+  const res = await fetch(`${process.env.NEXT_URL_POKEMON}${id}`)
 
-    const data = await res.json()
+  if (!res.ok) {
+    return { notFound: true }
+  }
 
-    return {
-        props: {pokemon: data, urlImagem: `${process.env.NEXT_URL_IMAGE_POKEMON}${id}.png`}
+  const data = await res.json()
+
+  return {
+    props: {
+      pokemon: data,
+      urlImagem: `${process.env.NEXT_URL_IMAGE_POKEMON}${id}.png`
     }
+  }
 }
 
-export default function Pokemon({pokemon, urlImagem}) {
-    return(
-        <>
-            <div className={styles.pokemon_container}>
-                <h1 className={styles.title}>{pokemon.name}</h1>
-                <Image src={`${urlImagem}`} height="200" width="200" alt={pokemon.name}/>
-                <div>
-                    <h3>Número:</h3>
-                    <p>{pokemon.id}</p>
-                </div>
-                <div>
-                    <h3>Tipos:</h3>
-                    <div className={styles.types_container}>
-                        {pokemon.types.map((item, index) => (
-                            <span key={index} className={`${styles.type} ${styles['type_' + item.type.name]}`}>{item.type.name}</span>
-                        ))}
-                    </div>
-                </div>
-                <div className={styles.data_container}>
-                    <div className={styles.data_height}>
-                        <h4>Altura:</h4>
-                        <p>{pokemon.height * 10} cm</p>
-                    </div>
-                    <div className={styles.data_weight}>
-                        <h4>Peso:</h4>
-                        <p>{pokemon.weight / 10} kg</p>
-                    </div>
-                </div>
+export default function Pokemon({ pokemon, urlImagem }) {
+  return (
+    <>
+      <div className={styles.pokemon_container}>
+        <Link href="/"><a className={styles.back_btn}>← Voltar</a></Link>
+
+        <h1 className={styles.title}>{pokemon.name}</h1>
+        <Image src={urlImagem} height="200" width="200" alt={pokemon.name} />
+
+        <div>
+          <h3>Número:</h3>
+          <p>#{pokemon.id}</p>
+        </div>
+
+        <div>
+          <h3>Tipos:</h3>
+          <div className={styles.types_container}>
+            {pokemon.types.map((item, index) => (
+              <span
+                key={index}
+                className={`${styles.type} ${styles['type_' + item.type.name]}`}
+              >
+                {item.type.name}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className={styles.data_container}>
+          <div className={styles.data_height}>
+            <h4>Altura:</h4>
+            <p>{pokemon.height * 10} cm</p>
+          </div>
+          <div className={styles.data_weight}>
+            <h4>Peso:</h4>
+            <p>{pokemon.weight / 10} kg</p>
+          </div>
+        </div>
+
+        <div className={styles.abilities_section}>
+          <h3>Habilidades:</h3>
+          <div className={styles.abilities_container}>
+            {pokemon.abilities.map((item, index) => (
+              <span
+                key={index}
+                className={`${styles.ability} ${item.is_hidden ? styles.ability_hidden : ''}`}
+              >
+                {item.ability.name}
+                {item.is_hidden && <small> (oculta)</small>}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className={styles.stats_section}>
+          <h3>Stats Base:</h3>
+          {pokemon.stats.map((item, index) => (
+            <div key={index} className={styles.stat_row}>
+              <span className={styles.stat_name}>{item.stat.name}</span>
+              <div className={styles.stat_bar_bg}>
+                <div
+                  className={styles.stat_bar}
+                  style={{ width: `${Math.min(100, (item.base_stat / 255) * 100)}%` }}
+                />
+              </div>
+              <span className={styles.stat_value}>{item.base_stat}</span>
             </div>
-        </>
-    )
+          ))}
+        </div>
+      </div>
+    </>
+  )
 }

--- a/styles/About.module.css
+++ b/styles/About.module.css
@@ -1,16 +1,29 @@
 .about {
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  max-width: 650px;
+  margin: 0 auto;
+  text-align: center;
+  gap: 1.2em;
+}
+
+.about h1 {
+  font-size: 2em;
+  color: #E33D33;
 }
 
 .about p {
-    font-size: 2em;
-    margin-bottom: 1em;
+  font-size: 1em;
+  line-height: 1.7;
+  color: #444;
+  max-width: 500px;
 }
 
-.about a {
-    max-width: 500px;
-    margin: 0 auto 1.5m;
-    line-height: 1.4;
+.about code {
+  background: #eee;
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.9em;
 }

--- a/styles/Contact.module.css
+++ b/styles/Contact.module.css
@@ -1,0 +1,65 @@
+.contact {
+  max-width: 580px;
+  margin: 0 auto;
+}
+
+.contact h1 {
+  font-size: 2em;
+  color: #E33D33;
+  margin-bottom: 0.4em;
+}
+
+.contact > p {
+  color: #555;
+  margin-bottom: 2em;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2em;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4em;
+}
+
+.field label {
+  font-weight: bold;
+  font-size: 0.9em;
+}
+
+.field input,
+.field textarea {
+  padding: 0.7em 1em;
+  border: 2px solid #ddd;
+  border-radius: 5px;
+  font-size: 1em;
+  font-family: Helvetica;
+  resize: vertical;
+  transition: 0.3s;
+}
+
+.field input:focus,
+.field textarea:focus {
+  outline: none;
+  border-color: #E33D33;
+}
+
+.form button {
+  align-self: flex-start;
+  padding: 0.7em 2em;
+  background: #333;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  font-size: 1em;
+  cursor: pointer;
+  transition: 0.3s;
+}
+
+.form button:hover {
+  background: #E33D33;
+}

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-bottom: 2em;
+  margin-bottom: 1.5em;
 }
 
 .title {
@@ -16,11 +16,150 @@
   color: #333;
 }
 
+.filters {
+  max-width: 1100px;
+  margin: 0 auto 2em;
+}
+
+.search_form {
+  display: flex;
+  gap: 0.5em;
+  margin-bottom: 1em;
+}
+
+.search_input {
+  flex: 1;
+  padding: 0.6em 1em;
+  border: 2px solid #333;
+  border-radius: 5px;
+  font-size: 1em;
+  outline: none;
+}
+
+.search_input:focus {
+  border-color: #E33D33;
+}
+
+.search_btn {
+  padding: 0.6em 1.4em;
+  background: #333;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  font-size: 1em;
+  cursor: pointer;
+  transition: 0.3s;
+}
+
+.search_btn:hover {
+  background: #E33D33;
+}
+
+.clear_btn {
+  padding: 0.6em 1.4em;
+  background: #888;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  font-size: 1em;
+  cursor: pointer;
+  transition: 0.3s;
+}
+
+.clear_btn:hover {
+  background: #555;
+}
+
+.types_filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+}
+
+.type_btn {
+  padding: 0.4em 0.9em;
+  border: 2px solid transparent;
+  border-radius: 5px;
+  cursor: pointer;
+  color: #fff;
+  font-size: 0.82em;
+  font-weight: bold;
+  transition: 0.2s;
+  opacity: 0.75;
+}
+
+.type_btn:hover,
+.active {
+  opacity: 1;
+  transform: scale(1.08);
+  border-color: rgba(0, 0, 0, 0.3);
+}
+
+.type_btn_normal   { background-color: #aa9; color: #333; }
+.type_btn_fire     { background-color: #f42; }
+.type_btn_water    { background-color: #39f; }
+.type_btn_grass    { background-color: #7c5; }
+.type_btn_electric { background-color: #fc3; color: #333; }
+.type_btn_ice      { background-color: #6cf; color: #333; }
+.type_btn_fighting { background-color: #b54; }
+.type_btn_poison   { background-color: #a59; }
+.type_btn_ground   { background-color: #db5; color: #333; }
+.type_btn_flying   { background-color: #89f; }
+.type_btn_psychic  { background-color: #f59; }
+.type_btn_bug      { background-color: #ab2; }
+.type_btn_rock     { background-color: #ba6; }
+.type_btn_ghost    { background-color: #66b; }
+.type_btn_dragon   { background-color: #76e; }
+.type_btn_dark     { background-color: #754; }
+.type_btn_steel    { background-color: #aab; color: #333; }
+.type_btn_fairy    { background-color: #e9e; color: #333; }
+
 .pokemon_container {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   max-width: 1100px;
   margin: 0 auto;
+}
+
+.empty {
+  text-align: center;
+  font-size: 1.2em;
+  color: #777;
+  margin: 3em auto;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1em;
+  margin: 2em 0;
+}
+
+.page_btn {
+  padding: 0.6em 1.4em;
+  background: #333;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  font-size: 1em;
+  cursor: pointer;
+  transition: 0.3s;
+}
+
+.page_btn:hover:not(:disabled) {
+  background: #E33D33;
+}
+
+.page_btn:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+.page_info {
+  font-size: 1em;
+  font-weight: bold;
+  color: #333;
 }

--- a/styles/Pokemon.module.css
+++ b/styles/Pokemon.module.css
@@ -1,127 +1,165 @@
 .pokemon_container {
-    text-align: center;
-  }
-  
-  .title {
-    font-size: 2.5em;
-    text-transform: capitalize;
-    background-color: #333;
-    color: #fff;
-    padding: 0.3em;
-    margin: 0.8em auto;
-    width: 300px;
-  }
-  
-  .pokemon_container h3 {
-    margin: 0.6em auto;
-    font-size: 1.2em;
-  }
-  
-  .types_container {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-  
-  .type {
-    padding: 0.6em 1em;
-    color: #fff;
-    background-color: #000;
-    margin-right: 0.5em;
-    border: 1px solid #ccc;
-    border-radius: 6px;
-    text-transform: uppercase;
-    font-size: 0.8em;
-  }
-  
-  .type_normal {
-    background-color: #aa9;
-  }
-  
-  .type_fire {
-    background-color: #f42;
-  }
-  
-  .type_water {
-    background-color: #39f;
-  }
-  
-  .type_eletric {
-    background-color: #fc3;
-  }
-  
-  .type_grass {
-    background-color: #7c5;
-  }
-  
-  .type_ice {
-    background-color: #6cf;
-  }
-  
-  .type_fighting {
-    background-color: #b54;
-  }
-  
-  .type_poison {
-    background-color: #a59;
-  }
-  
-  .type_ground {
-    background-color: #db5;
-  }
-  
-  .type_flying {
-    background-color: #89f;
-  }
-  
-  .type_psychic {
-    background-color: #f59;
-  }
-  
-  .type_bug {
-    background-color: #ab2;
-  }
-  
-  .type_rock {
-    background-color: #ba6;
-  }
-  
-  .type_ghost {
-    background-color: #66b;
-  }
-  
-  .type_dragon {
-    background-color: #76e;
-  }
-  
-  .type_dark {
-    background-color: #754;
-  }
-  
-  .type_steel {
-    background-color: #aab;
-  }
-  
-  .type_fairy {
-    background-color: #e9e;
-  }
-  
-  .data_container {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-top: 0.5em;
-  }
-  
-  .data_container div {
-    margin: 1em 0;
-    padding: 0 1em;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-  }
-  
-  .data_height {
-    border-right: 1px solid #ccc;
-  }
+  text-align: center;
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+.back_btn {
+  display: inline-block;
+  text-decoration: none;
+  color: #333;
+  font-weight: bold;
+  margin-bottom: 1em;
+  padding: 0.4em 0.8em;
+  border: 2px solid #333;
+  border-radius: 5px;
+  transition: 0.3s;
+}
+
+.back_btn:hover {
+  background: #333;
+  color: #fff;
+}
+
+.title {
+  font-size: 2.5em;
+  text-transform: capitalize;
+  background-color: #333;
+  color: #fff;
+  padding: 0.3em;
+  margin: 0.8em auto;
+  width: 300px;
+}
+
+.pokemon_container h3 {
+  margin: 0.8em auto 0.4em;
+  font-size: 1.1em;
+}
+
+.types_container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.type {
+  padding: 0.6em 1em;
+  color: #fff;
+  background-color: #000;
+  margin-right: 0.5em;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  text-transform: uppercase;
+  font-size: 0.8em;
+}
+
+.type_normal   { background-color: #aa9; color: #333; }
+.type_fire     { background-color: #f42; }
+.type_water    { background-color: #39f; }
+.type_electric { background-color: #fc3; color: #333; }
+.type_grass    { background-color: #7c5; }
+.type_ice      { background-color: #6cf; color: #333; }
+.type_fighting { background-color: #b54; }
+.type_poison   { background-color: #a59; }
+.type_ground   { background-color: #db5; color: #333; }
+.type_flying   { background-color: #89f; }
+.type_psychic  { background-color: #f59; }
+.type_bug      { background-color: #ab2; }
+.type_rock     { background-color: #ba6; }
+.type_ghost    { background-color: #66b; }
+.type_dragon   { background-color: #76e; }
+.type_dark     { background-color: #754; }
+.type_steel    { background-color: #aab; color: #333; }
+.type_fairy    { background-color: #e9e; color: #333; }
+
+.data_container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.5em;
+}
+
+.data_container div {
+  margin: 1em 0;
+  padding: 0 1em;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.data_height {
+  border-right: 1px solid #ccc;
+}
+
+.abilities_section {
+  margin-top: 0.5em;
+}
+
+.abilities_container {
+  display: flex;
+  gap: 0.5em;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 0.4em;
+}
+
+.ability {
+  padding: 0.4em 0.8em;
+  background: #333;
+  color: #fff;
+  border-radius: 5px;
+  font-size: 0.85em;
+  text-transform: capitalize;
+}
+
+.ability_hidden {
+  background: #888;
+}
+
+.stats_section {
+  margin: 1em auto 2em;
+  width: 340px;
+  text-align: left;
+}
+
+.stats_section h3 {
+  text-align: center;
+}
+
+.stat_row {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.stat_name {
+  width: 130px;
+  font-size: 0.8em;
+  text-transform: capitalize;
+  text-align: right;
+  color: #555;
+}
+
+.stat_bar_bg {
+  flex: 1;
+  background: #eee;
+  border-radius: 4px;
+  height: 10px;
+  overflow: hidden;
+}
+
+.stat_bar {
+  height: 100%;
+  background: #E33D33;
+  border-radius: 4px;
+  transition: width 0.6s ease;
+}
+
+.stat_value {
+  width: 28px;
+  font-size: 0.8em;
+  font-weight: bold;
+  text-align: right;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -7,4 +7,5 @@
 
 .main-container {
   min-height: 70vh;
+  padding: 1.5em;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
- Home page migrada para getServerSideProps com suporte a query params (page, type, search)
- Paginação funcional em todas as listagens (geral, por tipo e por nome)
- Busca por nome: filtra entre todos os Pokémon (~1300) com paginação
- Filtro por tipo: 18 tipos com botões coloridos, busca via endpoint /type da PokéAPI
- Página de detalhe: adicionados stats base (barras visuais) e habilidades
- Detalhe: fallback 'blocking' para gerar qualquer Pokémon sob demanda
- Corrigido bug: CSS type_eletric → type_electric
- Página Sobre: conteúdo real sobre o projeto
- Página Contato: formulário com nome, e-mail e mensagem
- Correção de layout e typo no About.module.css
- Padding adicionado ao main-container em globals.css