### PR TITLE
fix: URL do botão Liga Pokémon

### DIFF
--- a/pages/pokemon/[pokemonId].js
+++ b/pages/pokemon/[pokemonId].js
@@ -31,7 +31,7 @@ export default function Pokemon({ pokemon, urlImagem }) {
   const { getStatus, toggle } = useCollection()
   const status = getStatus(pokemon.id)
 
-  const ligaUrl = `https://www.ligapokemon.com.br/?view=cards&s=${encodeURIComponent(pokemon.name)}`
+  const ligaUrl = `https://www.ligapokemon.com.br/?view=pokedex/pokemon&id=${pokemon.id}`
 
   return (
     <>


### PR DESCRIPTION
Corrige URL do botão para usar o endpoint correto da Pokédex da Liga Pokémon.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkWJQiZF6bqFECg8Yas8w6)_