### PR TITLE
fix: botão voltar redesenhado

### DIFF
--- a/pages/pokemon/[pokemonId].js
+++ b/pages/pokemon/[pokemonId].js
@@ -63,9 +63,11 @@ export default function Pokemon({ pokemon, urlImagem, evolutionChain }) {
 
   return (
     <>
-      <div className={styles.pokemon_container}>
+      <div className={styles.back_row}>
         <Link href="/"><a className={styles.back_btn}>← Voltar</a></Link>
+      </div>
 
+      <div className={styles.pokemon_container}>
         <h1 className={styles.title}>{pokemon.name}</h1>
         <Image src={urlImagem} height="200" width="200" alt={pokemon.name} />
 

--- a/styles/Pokemon.module.css
+++ b/styles/Pokemon.module.css
@@ -4,21 +4,23 @@
   margin: 0 auto;
 }
 
+.back_row {
+  max-width: 500px;
+  margin: 0 auto 0.5em;
+}
+
 .back_btn {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   text-decoration: none;
-  color: #333;
-  font-weight: bold;
-  margin-bottom: 1em;
-  padding: 0.4em 0.8em;
-  border: 2px solid #333;
-  border-radius: 5px;
-  transition: 0.3s;
+  color: #888;
+  font-size: 0.875em;
+  padding: 0.2em 0;
+  transition: color 0.2s;
 }
 
 .back_btn:hover {
-  background: #333;
-  color: #fff;
+  color: #E33D33;
 }
 
 .collection_btns {


### PR DESCRIPTION
Remove a borda e o estilo de botão. Agora é um link sutil em cinza alinhado à esquerda, separado do conteúdo centralizado da página.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkWJQiZF6bqFECg8Yas8w6)_