### PR TITLE
feat: botão voltar no estilo pokébola flutuante

### DIFF
--- a/pages/pokemon/[pokemonId].js
+++ b/pages/pokemon/[pokemonId].js
@@ -63,9 +63,11 @@ export default function Pokemon({ pokemon, urlImagem, evolutionChain }) {
 
   return (
     <>
-      <div className={styles.back_row}>
-        <Link href="/"><a className={styles.back_btn}>← Voltar</a></Link>
-      </div>
+      <Link href="/">
+        <a className={styles.back_btn} title="Voltar">
+          <span className={styles.back_arrow}>&#8592;</span>
+        </a>
+      </Link>
 
       <div className={styles.pokemon_container}>
         <h1 className={styles.title}>{pokemon.name}</h1>

--- a/styles/Pokemon.module.css
+++ b/styles/Pokemon.module.css
@@ -4,23 +4,46 @@
   margin: 0 auto;
 }
 
-.back_row {
-  max-width: 500px;
-  margin: 0 auto 0.5em;
-}
-
 .back_btn {
-  display: inline-flex;
+  position: fixed;
+  top: 76px;
+  left: 1em;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: linear-gradient(180deg,
+    #E33D33 0%, #E33D33 46%,
+    #222    46%, #222    54%,
+    #f5f5f5 54%, #f5f5f5 100%
+  );
+  border: 3px solid #222;
+  box-shadow: 0 3px 14px rgba(0,0,0,0.35);
+  display: flex;
   align-items: center;
+  justify-content: center;
   text-decoration: none;
-  color: #888;
-  font-size: 0.875em;
-  padding: 0.2em 0;
-  transition: color 0.2s;
+  z-index: 50;
+  transition: transform 0.25s, box-shadow 0.25s;
 }
 
 .back_btn:hover {
-  color: #E33D33;
+  transform: scale(1.12) rotate(-20deg);
+  box-shadow: 0 6px 20px rgba(0,0,0,0.4);
+}
+
+.back_arrow {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2.5px solid #222;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8em;
+  font-weight: bold;
+  color: #222;
+  line-height: 1;
 }
 
 .collection_btns {


### PR DESCRIPTION
Botão flutuante fixo no canto superior esquerdo com design de Pokébola em CSS puro. Metade vermelha, metade branca, linha central preta e botão central com a seta. Rotaciona ao hover.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkWJQiZF6bqFECg8Yas8w6)_